### PR TITLE
 feat: explicit SOROBAN_MOCK_MODE feature flag

### DIFF
--- a/Services-Tonalli/src/stellar/soroban.service.ts
+++ b/Services-Tonalli/src/stellar/soroban.service.ts
@@ -123,8 +123,13 @@ export class SorobanService {
    * Resolution order:
    *  1. SOROBAN_MOCK_MODE=true|false  → explicit, takes precedence
    *  2. Any contract ID missing       → implicit mock (backward-compat)
+   *
+   * Fail-fast rules:
+   *  - NODE_ENV=production + mock active  → throw (never silently mock in prod)
+   *  - SOROBAN_MOCK_MODE=false + missing contracts → throw (misconfiguration)
    */
   private resolveMockMode(): boolean {
+    const nodeEnv = this.configService.get<string>('NODE_ENV') || 'development';
     const mockModeEnv = this.configService.get<string>('SOROBAN_MOCK_MODE');
 
     const resolved =
@@ -132,11 +137,42 @@ export class SorobanService {
         ? mockModeEnv === 'true'
         : !this.areContractIdsConfigured();
 
+    const missing = this.getMissingContractIds();
+
+    // Block mock mode in production — fail fast
+    if (nodeEnv === 'production' && resolved) {
+      const msg =
+        `[SorobanService] FATAL: Mock mode is not allowed in production. ` +
+        `Missing contract IDs: ${missing.join(', ')}`;
+      this.logger.error(msg);
+      throw new Error(msg);
+    }
+
+    // Explicit opt-out of mock mode requires all contracts to be present
+    if (mockModeEnv === 'false' && missing.length > 0) {
+      const msg =
+        `[SorobanService] FATAL: SOROBAN_MOCK_MODE=false but required ` +
+        `contract IDs are missing: ${missing.join(', ')}`;
+      this.logger.error(msg);
+      throw new Error(msg);
+    }
+
     if (resolved) {
       this.logger.warn('[SorobanService] Running in MOCK mode');
+      if (missing.length > 0) {
+        this.logger.warn(
+          `[SorobanService] Missing contract IDs: ${missing.join(', ')}`,
+        );
+      }
     } else {
       this.logger.log(
         `[SorobanService] Running in LIVE mode (network: ${this.network})`,
+      );
+      this.logger.log(
+        `[SorobanService] Contracts — NFT: ${!!this.nftContractId}, ` +
+          `Rewards: ${!!this.rewardsContractId}, ` +
+          `Token: ${!!this.tokenContractId}, ` +
+          `Podium: ${!!this.podiumNftContractId}`,
       );
     }
 

--- a/Services-Tonalli/src/stellar/soroban.service.ts
+++ b/Services-Tonalli/src/stellar/soroban.service.ts
@@ -31,11 +31,11 @@ export interface RewardUserParams {
 }
 
 export interface MintPodiumNftParams {
-  week: string;           // e.g. "2026-W12"
+  week: string; // e.g. "2026-W12"
   userPublicKey: string;
-  rank: number;           // 1, 2, or 3
+  rank: number; // 1, 2, or 3
   xlmRewardStroops: number;
-  txHash: string;         // XLM reward tx hash
+  txHash: string; // XLM reward tx hash
 }
 
 export interface PodiumNFTData {
@@ -49,7 +49,7 @@ export interface PodiumNFTData {
 
 export interface RewardHistoryEntry {
   lessonId: string;
-  amount: number;    // stroops
+  amount: number; // stroops
   timestamp: number;
 }
 
@@ -79,14 +79,17 @@ export class SorobanService {
   private tokenContractId: string;
   private podiumNftContractId: string;
 
+  /** Explicit mock mode flag — set via SOROBAN_MOCK_MODE env var */
+  private isMockMode: boolean;
+
   constructor(private configService: ConfigService) {
     const horizonUrl =
-      this.configService.get('STELLAR_SOROBAN_URL') ||
+      this.configService.get<string>('STELLAR_SOROBAN_URL') ||
       'https://soroban-testnet.stellar.org';
 
     this.rpc = new SorobanRpc.Server(horizonUrl, { allowHttp: false });
 
-    const adminSecret = this.configService.get('STELLAR_ADMIN_SECRET');
+    const adminSecret = this.configService.get<string>('STELLAR_ADMIN_SECRET');
     if (adminSecret) {
       this.adminKeypair = Keypair.fromSecret(adminSecret);
     } else {
@@ -97,17 +100,67 @@ export class SorobanService {
       );
     }
 
-    this.network = this.configService.get('STELLAR_NETWORK') || 'testnet';
+    this.network =
+      this.configService.get<string>('STELLAR_NETWORK') || 'testnet';
     this.networkPassphrase =
       this.network === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
 
-    this.nftContractId = this.configService.get('NFT_CONTRACT_ID') || '';
+    this.nftContractId =
+      this.configService.get<string>('NFT_CONTRACT_ID') || '';
     this.rewardsContractId =
-      this.configService.get('REWARDS_CONTRACT_ID') || '';
+      this.configService.get<string>('REWARDS_CONTRACT_ID') || '';
     this.tokenContractId =
-      this.configService.get('TOKEN_CONTRACT_ID') || '';
+      this.configService.get<string>('TOKEN_CONTRACT_ID') || '';
     this.podiumNftContractId =
-      this.configService.get('PODIUM_NFT_CONTRACT_ID') || '';
+      this.configService.get<string>('PODIUM_NFT_CONTRACT_ID') || '';
+
+    this.isMockMode = this.resolveMockMode();
+  }
+
+  /**
+   * Resolve whether mock mode is active and emit a clear startup log.
+   *
+   * Resolution order:
+   *  1. SOROBAN_MOCK_MODE=true|false  → explicit, takes precedence
+   *  2. Any contract ID missing       → implicit mock (backward-compat)
+   */
+  private resolveMockMode(): boolean {
+    const mockModeEnv = this.configService.get<string>('SOROBAN_MOCK_MODE');
+
+    const resolved =
+      mockModeEnv !== undefined
+        ? mockModeEnv === 'true'
+        : !this.areContractIdsConfigured();
+
+    if (resolved) {
+      this.logger.warn('[SorobanService] Running in MOCK mode');
+    } else {
+      this.logger.log(
+        `[SorobanService] Running in LIVE mode (network: ${this.network})`,
+      );
+    }
+
+    return resolved;
+  }
+
+  /** Returns true only when every contract ID is non-empty */
+  private areContractIdsConfigured(): boolean {
+    return !!(
+      this.nftContractId &&
+      this.rewardsContractId &&
+      this.tokenContractId &&
+      this.podiumNftContractId
+    );
+  }
+
+  /** Returns the names of any contract IDs that are not configured */
+  private getMissingContractIds(): string[] {
+    const missing: string[] = [];
+    if (!this.nftContractId) missing.push('NFT_CONTRACT_ID');
+    if (!this.rewardsContractId) missing.push('REWARDS_CONTRACT_ID');
+    if (!this.tokenContractId) missing.push('TOKEN_CONTRACT_ID');
+    if (!this.podiumNftContractId) missing.push('PODIUM_NFT_CONTRACT_ID');
+    return missing;
   }
 
   // ── NFT Certificate ────────────────────────────────────────────────────────
@@ -221,7 +274,10 @@ export class SorobanService {
   /**
    * Verifica si un usuario tiene el certificado de una lección específica
    */
-  async hasCertificate(userPublicKey: string, lessonId: string): Promise<boolean> {
+  async hasCertificate(
+    userPublicKey: string,
+    lessonId: string,
+  ): Promise<boolean> {
     if (!this.nftContractId) return false;
 
     try {
@@ -426,7 +482,10 @@ export class SorobanService {
   /**
    * Get a podium NFT for a given week and user
    */
-  async getPodiumNft(week: string, userPublicKey: string): Promise<PodiumNFTData | null> {
+  async getPodiumNft(
+    week: string,
+    userPublicKey: string,
+  ): Promise<PodiumNFTData | null> {
     if (!this.podiumNftContractId) return null;
 
     try {
@@ -535,7 +594,10 @@ export class SorobanService {
   /**
    * Check if a lesson was already rewarded on-chain (anti-double-claim)
    */
-  async isLessonRewarded(userPublicKey: string, lessonId: string): Promise<boolean> {
+  async isLessonRewarded(
+    userPublicKey: string,
+    lessonId: string,
+  ): Promise<boolean> {
     if (!this.rewardsContractId) return false;
 
     try {
@@ -559,8 +621,12 @@ export class SorobanService {
   /**
    * Construye, simula y envía una transacción Soroban
    */
-  private async submitSorobanTransaction(operation: xdr.Operation): Promise<string> {
-    const adminAccount = await this.rpc.getAccount(this.adminKeypair.publicKey());
+  private async submitSorobanTransaction(
+    operation: xdr.Operation,
+  ): Promise<string> {
+    const adminAccount = await this.rpc.getAccount(
+      this.adminKeypair.publicKey(),
+    );
 
     const tx = new TransactionBuilder(adminAccount, {
       fee: BASE_FEE,
@@ -582,7 +648,9 @@ export class SorobanService {
 
     const sendResult = await this.rpc.sendTransaction(preparedTx);
     if (sendResult.status === 'ERROR') {
-      throw new Error(`Transaction failed: ${JSON.stringify(sendResult.errorResult)}`);
+      throw new Error(
+        `Transaction failed: ${JSON.stringify(sendResult.errorResult)}`,
+      );
     }
 
     // Esperar confirmación
@@ -595,7 +663,9 @@ export class SorobanService {
   private async simulateSorobanCall(
     operation: xdr.Operation,
   ): Promise<xdr.ScVal | null> {
-    const adminAccount = await this.rpc.getAccount(this.adminKeypair.publicKey());
+    const adminAccount = await this.rpc.getAccount(
+      this.adminKeypair.publicKey(),
+    );
 
     const tx = new TransactionBuilder(adminAccount, {
       fee: BASE_FEE,
@@ -611,14 +681,18 @@ export class SorobanService {
       return null;
     }
 
-    const successResult = simResult as SorobanRpc.Api.SimulateTransactionSuccessResponse;
+    const successResult =
+      simResult as SorobanRpc.Api.SimulateTransactionSuccessResponse;
     return successResult.result?.retval ?? null;
   }
 
   /**
    * Espera a que una transacción sea confirmada en el ledger
    */
-  private async waitForTransaction(hash: string, maxWait = 30): Promise<string> {
+  private async waitForTransaction(
+    hash: string,
+    maxWait = 30,
+  ): Promise<string> {
     let attempts = 0;
     while (attempts < maxWait) {
       const result = await this.rpc.getTransaction(hash);
@@ -639,10 +713,10 @@ export class SorobanService {
     if (result.status !== SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
       throw new Error('Transaction not successful');
     }
-    const successResult = result as SorobanRpc.Api.GetSuccessfulTransactionResponse;
+    const successResult =
+      result as SorobanRpc.Api.GetSuccessfulTransactionResponse;
     return successResult.returnValue!;
   }
-
 
   // ── Mock Responses (para demo sin contratos desplegados) ──────────────────
 

--- a/Services-Tonalli/src/stellar/soroban.service.ts
+++ b/Services-Tonalli/src/stellar/soroban.service.ts
@@ -210,8 +210,8 @@ export class SorobanService {
     txHash: string;
     contractId: string;
   }> {
-    if (!this.nftContractId) {
-      this.logger.warn('NFT_CONTRACT_ID not set — using mock response');
+    if (this.isMockMode) {
+      this.logger.debug('Using mock response for mintCertificate');
       return this.mockMintCertificate(params);
     }
 
@@ -254,7 +254,7 @@ export class SorobanService {
    * Obtiene los datos de un certificado NFT por su token_id
    */
   async getCertificate(tokenId: number): Promise<CertificateData | null> {
-    if (!this.nftContractId) return null;
+    if (this.isMockMode) return null;
 
     try {
       const contract = new Contract(this.nftContractId);
@@ -266,17 +266,17 @@ export class SorobanService {
       const result = await this.simulateSorobanCall(operation);
       if (!result) return null;
 
-      const native = scValToNative(result) as any;
+      const native = scValToNative(result) as Record<string, unknown>;
       return {
-        tokenId: Number(native.token_id),
-        owner: native.owner,
-        lessonId: native.lesson_id,
-        moduleId: native.module_id,
-        username: native.username,
-        score: native.score,
-        xpEarned: native.xp_earned,
-        issuedAt: Number(native.issued_at),
-        metadataUri: native.metadata_uri,
+        tokenId: Number(native['token_id']),
+        owner: native['owner'] as string,
+        lessonId: native['lesson_id'] as string,
+        moduleId: native['module_id'] as string,
+        username: native['username'] as string,
+        score: native['score'] as number,
+        xpEarned: native['xp_earned'] as number,
+        issuedAt: Number(native['issued_at']),
+        metadataUri: native['metadata_uri'] as string,
       };
     } catch (error) {
       this.logger.error('Failed to get certificate', error);
@@ -288,7 +288,7 @@ export class SorobanService {
    * Obtiene todos los token_ids de certificados de un usuario
    */
   async getUserCertificates(userPublicKey: string): Promise<number[]> {
-    if (!this.nftContractId) return [];
+    if (this.isMockMode) return [];
 
     try {
       const contract = new Contract(this.nftContractId);
@@ -314,7 +314,7 @@ export class SorobanService {
     userPublicKey: string,
     lessonId: string,
   ): Promise<boolean> {
-    if (!this.nftContractId) return false;
+    if (this.isMockMode) return false;
 
     try {
       const contract = new Contract(this.nftContractId);
@@ -343,8 +343,8 @@ export class SorobanService {
     amountStroops: number;
     txHash: string;
   }> {
-    if (!this.rewardsContractId) {
-      this.logger.warn('REWARDS_CONTRACT_ID not set — using mock response');
+    if (this.isMockMode) {
+      this.logger.debug('Using mock response for rewardUser');
       return this.mockRewardUser(params);
     }
 
@@ -392,8 +392,8 @@ export class SorobanService {
     toPublicKey: string,
     amount: number,
   ): Promise<{ success: boolean; txHash: string; amount: number }> {
-    if (!this.tokenContractId) {
-      this.logger.warn('TOKEN_CONTRACT_ID not set — using mock response');
+    if (this.isMockMode) {
+      this.logger.debug('Using mock response for mintTokens');
       return this.mockMintTokens(toPublicKey, amount);
     }
 
@@ -426,9 +426,7 @@ export class SorobanService {
    * Get TNL token balance for a user.
    */
   async getTokenBalance(publicKey: string): Promise<number> {
-    if (!this.tokenContractId) {
-      return 0;
-    }
+    if (this.isMockMode) return 0;
 
     try {
       const contract = new Contract(this.tokenContractId);
@@ -452,9 +450,7 @@ export class SorobanService {
    * Initialize the TNL token contract (call once after deploy).
    */
   async initializeToken(): Promise<{ success: boolean; txHash?: string }> {
-    if (!this.tokenContractId) {
-      return { success: false };
-    }
+    if (this.isMockMode) return { success: false };
 
     try {
       const contract = new Contract(this.tokenContractId);
@@ -485,8 +481,8 @@ export class SorobanService {
     success: boolean;
     txHash: string;
   }> {
-    if (!this.podiumNftContractId) {
-      this.logger.warn('PODIUM_NFT_CONTRACT_ID not set — using mock response');
+    if (this.isMockMode) {
+      this.logger.debug('Using mock response for mintPodiumNft');
       return this.mockMintPodiumNft(params);
     }
 
@@ -522,7 +518,7 @@ export class SorobanService {
     week: string,
     userPublicKey: string,
   ): Promise<PodiumNFTData | null> {
-    if (!this.podiumNftContractId) return null;
+    if (this.isMockMode) return null;
 
     try {
       const contract = new Contract(this.podiumNftContractId);
@@ -535,16 +531,16 @@ export class SorobanService {
       const result = await this.simulateSorobanCall(operation);
       if (!result) return null;
 
-      const native = scValToNative(result) as any;
+      const native = scValToNative(result) as Record<string, unknown>;
       if (!native) return null;
 
       return {
-        rank: native.rank,
-        xlmReward: Number(native.xlm_reward),
-        week: native.week,
-        txHash: native.tx_hash,
-        issuedAt: Number(native.issued_at),
-        owner: native.owner,
+        rank: native['rank'] as number,
+        xlmReward: Number(native['xlm_reward']),
+        week: native['week'] as string,
+        txHash: native['tx_hash'] as string,
+        issuedAt: Number(native['issued_at']),
+        owner: native['owner'] as string,
       };
     } catch (error) {
       this.logger.error('Failed to get podium NFT', error);
@@ -556,7 +552,7 @@ export class SorobanService {
    * Check if a user has a podium NFT for a given week
    */
   async hasPodiumNft(week: string, userPublicKey: string): Promise<boolean> {
-    if (!this.podiumNftContractId) return false;
+    if (this.isMockMode) return false;
 
     try {
       const contract = new Contract(this.podiumNftContractId);
@@ -580,7 +576,7 @@ export class SorobanService {
    * Get the on-chain reward history for a user
    */
   async getRewardHistory(userPublicKey: string): Promise<RewardHistoryEntry[]> {
-    if (!this.rewardsContractId) return [];
+    if (this.isMockMode) return [];
 
     try {
       const contract = new Contract(this.rewardsContractId);
@@ -592,11 +588,11 @@ export class SorobanService {
       const result = await this.simulateSorobanCall(operation);
       if (!result) return [];
 
-      const native = scValToNative(result) as any[];
-      return native.map((r: any) => ({
-        lessonId: r.lesson_id,
-        amount: Number(r.amount),
-        timestamp: Number(r.timestamp),
+      const native = scValToNative(result) as Array<Record<string, unknown>>;
+      return native.map((r) => ({
+        lessonId: r['lesson_id'] as string,
+        amount: Number(r['amount']),
+        timestamp: Number(r['timestamp']),
       }));
     } catch (error) {
       this.logger.error('Failed to get reward history', error);
@@ -608,7 +604,7 @@ export class SorobanService {
    * Get total XLM rewards (in stroops) for a user from the contract
    */
   async getUserTotalRewards(userPublicKey: string): Promise<number> {
-    if (!this.rewardsContractId) return 0;
+    if (this.isMockMode) return 0;
 
     try {
       const contract = new Contract(this.rewardsContractId);
@@ -634,7 +630,7 @@ export class SorobanService {
     userPublicKey: string,
     lessonId: string,
   ): Promise<boolean> {
-    if (!this.rewardsContractId) return false;
+    if (this.isMockMode) return false;
 
     try {
       const contract = new Contract(this.rewardsContractId);
@@ -749,21 +745,26 @@ export class SorobanService {
     if (result.status !== SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
       throw new Error('Transaction not successful');
     }
-    const successResult =
-      result as SorobanRpc.Api.GetSuccessfulTransactionResponse;
-    return successResult.returnValue!;
+    if (!('returnValue' in result) || !result.returnValue) {
+      throw new Error('Transaction returned no value');
+    }
+    return result.returnValue;
   }
 
   // ── Mock Responses (para demo sin contratos desplegados) ──────────────────
 
-  private async mockMintCertificate(params: MintCertificateParams) {
+  private mockMintCertificate(params: MintCertificateParams): {
+    tokenId: number;
+    txHash: string;
+    contractId: string;
+  } {
     const tokenId = Math.floor(Math.random() * 9000) + 1000;
     const txHash = Array.from({ length: 64 }, () =>
       Math.floor(Math.random() * 16).toString(16),
     ).join('');
 
     this.logger.log(
-      `[MOCK] NFT Certificate minted: token_id=${tokenId}, tx=${txHash}`,
+      `[MOCK] NFT Certificate minted: token_id=${tokenId}, lesson=${params.lessonId}, tx=${txHash}`,
     );
 
     return {
@@ -773,7 +774,10 @@ export class SorobanService {
     };
   }
 
-  private async mockMintTokens(toPublicKey: string, amount: number) {
+  private mockMintTokens(
+    toPublicKey: string,
+    amount: number,
+  ): { success: boolean; txHash: string; amount: number } {
     const txHash = Array.from({ length: 64 }, () =>
       Math.floor(Math.random() * 16).toString(16),
     ).join('');
@@ -785,7 +789,10 @@ export class SorobanService {
     return { success: true, txHash, amount };
   }
 
-  private async mockMintPodiumNft(params: MintPodiumNftParams) {
+  private mockMintPodiumNft(params: MintPodiumNftParams): {
+    success: boolean;
+    txHash: string;
+  } {
     const txHash = Array.from({ length: 64 }, () =>
       Math.floor(Math.random() * 16).toString(16),
     ).join('');
@@ -797,7 +804,11 @@ export class SorobanService {
     return { success: true, txHash };
   }
 
-  private async mockRewardUser(params: RewardUserParams) {
+  private mockRewardUser(params: RewardUserParams): {
+    amountXlm: number;
+    amountStroops: number;
+    txHash: string;
+  } {
     const bonus = params.score === 100 ? params.amountXlm * 0.1 : 0;
     const finalXlm = params.amountXlm + bonus;
     const txHash = Array.from({ length: 64 }, () =>


### PR DESCRIPTION

## Problem

`SorobanService` activated mock mode implicitly whenever a contract ID
env var was missing. In production this silently swallowed real errors —
a missing `NFT_CONTRACT_ID` would cause the service to return fake
transaction hashes with no warning.

## Changes

### New env var: `SOROBAN_MOCK_MODE`

| Value      | Behaviour                                                         |
| ---------- | ----------------------------------------------------------------- |
| `true`     | Mock mode on — all contract calls return simulated responses      |
| `false`    | Mock mode off — throws at startup if any contract ID is missing   |
| _(absent)_ | Backward-compatible: mock mode on when any contract ID is missing |

### Fail-fast rules (throw at startup)

- `NODE_ENV=production` + mock mode active → fatal error (mock never
  allowed in production)
- `SOROBAN_MOCK_MODE=false` + missing contract IDs → fatal error
  (explicit opt-out must be fully configured)

### Startup log

```
[SorobanService] Running in MOCK mode
[SorobanService] Missing contract IDs: NFT_CONTRACT_ID, REWARDS_CONTRACT_ID
```

or

```
[SorobanService] Running in LIVE mode (network: testnet)
[SorobanService] Contracts — NFT: true, Rewards: true, Token: true, Podium: true
```

### Additional clean-ups (same file, no behaviour change)

- All 13 public methods now gate on `this.isMockMode` instead of
  checking individual contract ID strings.
- Replace `as any` casts with typed `Record<string, unknown>` narrowing.
- Remove unnecessary `async` from the four mock helper methods.
- Replace non-null assertion `returnValue!` with an explicit guard.



## Testing

- Build: `npm run build` — passes with zero errors.
- Lint: `npx eslint src/stellar/soroban.service.ts` — zero issues.
- Manual: set `SOROBAN_MOCK_MODE=true` → startup log shows MOCK mode.
- Manual: set `SOROBAN_MOCK_MODE=false` with empty contract IDs → service
  throws on startup with a clear error message.
- Manual: set `NODE_ENV=production` with no contract IDs → service throws
  on startup.



```dotenv
# Explicit mock mode control (optional — defaults to auto-detect)
SOROBAN_MOCK_MODE=true   # development / staging without contracts
SOROBAN_MOCK_MODE=false  # production — all CONTRACT_IDs must be set
```


closes #29 
