### PR TITLE
Add CI pipeline via GitHub Actions

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,43 @@
+name: build-backend
+
+on:
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  build-backend:
+    name: nest build – TypeScript check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Services-Tonalli
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: Services-Tonalli/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (fails on TypeScript errors)
+        run: npm run build
+
+      - name: Run Jest with coverage (minimum 70%)
+        run: |
+          npm run test:cov -- \
+            --coverageThreshold='{"global":{"lines":70,"functions":70,"branches":70,"statements":70}}'
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: Services-Tonalli/coverage/

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,36 @@
+name: test-contracts
+
+on:
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  test-contracts:
+    name: cargo test – all contracts
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Services-Tonalli/contracts
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry & build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            Services-Tonalli/contracts/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Services-Tonalli/contracts/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Run cargo test (all contracts)
+        run: cargo test --workspace

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,31 @@
+name: build-frontend
+
+on:
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  build-frontend:
+    name: expo export – web bundle
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Movil-tonalli
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: Movil-tonalli/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web bundle (fails on errors)
+        run: npx expo export --platform web


### PR DESCRIPTION


Sets up automated CI checks that run on every pull request across all branches. The pipeline is split into three separate workflow files so each check runs and reports independently.

What was added
contracts.yml
 — Rust smart contract tests

Installs the stable Rust toolchain with the wasm32-unknown-unknown target
Caches the Cargo registry and build artifacts to speed up runs
Runs cargo test --workspace across all 5 Soroban contracts (nft-certificate, learn-to-earn, podio-nft, tonalli-token, interfaces)
backend.yml
 — NestJS build + test

Installs Node 20 and runs npm ci with cache
Runs nest build — fails the PR on any TypeScript error
Runs jest --coverage with a hard minimum of 70% on lines, functions, branches, and statements
Uploads the coverage report as a downloadable artifact on every run (pass or fail)
frontend.yml
 — Expo / React Native build

Installs Node 20 and runs npm ci with cache


closes #12