### PR TITLE
feat: add rate limiting to critical endpoints (#30)

### DIFF
--- a/Services-Tonalli/package-lock.json
+++ b/Services-Tonalli/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/schedule": "^6.1.1",
+        "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^11.0.0",
         "@stellar/stellar-sdk": "^14.6.1",
         "bcryptjs": "^3.0.3",
@@ -2568,6 +2569,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nestjs/typeorm": {

--- a/Services-Tonalli/package.json
+++ b/Services-Tonalli/package.json
@@ -30,6 +30,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^6.1.1",
+    "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
     "@stellar/stellar-sdk": "^14.6.1",
     "bcryptjs": "^3.0.3",

--- a/Services-Tonalli/src/app.module.ts
+++ b/Services-Tonalli/src/app.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
@@ -34,6 +36,23 @@ import { Streak } from './users/entities/streak.entity';
       envFilePath: '.env',
     }),
     ScheduleModule.forRoot(),
+    ThrottlerModule.forRoot([
+      {
+        name: 'default',
+        ttl: 60000,
+        limit: 60,
+      },
+      {
+        name: 'login',
+        ttl: 900000,
+        limit: 5,
+      },
+      {
+        name: 'quiz',
+        ttl: 60000,
+        limit: 10,
+      },
+    ]),
     TypeOrmModule.forRootAsync({
       useFactory: () => ({
         type: 'mysql',
@@ -42,8 +61,22 @@ import { Streak } from './users/entities/streak.entity';
         username: process.env.DB_USER || 'root',
         password: process.env.DB_PASS || '',
         database: process.env.DB_NAME || 'tonalli',
-        entities: [User, Lesson, Quiz, Progress, NFTCertificate, Streak, Chapter, ChapterModuleEntity, ChapterProgress, ChapterQuestion, WeeklyScore, PodiumReward, ActaCertificate],
-        synchronize: true,   // crea/actualiza tablas automáticamente
+        entities: [
+          User,
+          Lesson,
+          Quiz,
+          Progress,
+          NFTCertificate,
+          Streak,
+          Chapter,
+          ChapterModuleEntity,
+          ChapterProgress,
+          ChapterQuestion,
+          WeeklyScore,
+          PodiumReward,
+          ActaCertificate,
+        ],
+        synchronize: true, // crea/actualiza tablas automáticamente
         logging: false,
         charset: 'utf8mb4',
       }),
@@ -59,6 +92,12 @@ import { Streak } from './users/entities/streak.entity';
     ActaModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/Services-Tonalli/src/auth/auth.controller.ts
+++ b/Services-Tonalli/src/auth/auth.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
@@ -8,12 +9,14 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('register')
+  @Throttle({ default: { limit: 60, ttl: 60000 } })
   async register(@Body() dto: RegisterDto) {
     return this.authService.register(dto);
   }
 
   @Post('login')
   @HttpCode(HttpStatus.OK)
+  @Throttle({ login: { limit: 5, ttl: 900000 } })
   async login(@Body() dto: LoginDto) {
     return this.authService.login(dto);
   }

--- a/Services-Tonalli/src/chapters/chapters.controller.ts
+++ b/Services-Tonalli/src/chapters/chapters.controller.ts
@@ -1,7 +1,16 @@
 import {
-  Controller, Get, Post, Patch, Put, Delete,
-  Param, Body, UseGuards, Req,
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Put,
+  Delete,
+  Param,
+  Body,
+  UseGuards,
+  Req,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { ChaptersService } from './chapters.service';
 import { CreateChapterDto } from './dto/create-chapter.dto';
 import { UpdateChapterDto } from './dto/update-chapter.dto';
@@ -61,11 +70,16 @@ export class ChaptersController {
     @Body('percent') percent: number,
     @Req() req: any,
   ) {
-    return this.chaptersService.updateVideoProgress(moduleId, req.user.id, percent);
+    return this.chaptersService.updateVideoProgress(
+      moduleId,
+      req.user.id,
+      percent,
+    );
   }
 
   /** POST /api/chapters/modules/:moduleId/quiz/submit */
   @UseGuards(JwtAuthGuard)
+  @Throttle({ quiz: { limit: 10, ttl: 60000 } })
   @Post('modules/:moduleId/quiz/submit')
   submitQuiz(
     @Param('moduleId') moduleId: string,
@@ -83,7 +97,11 @@ export class ChaptersController {
     @Body('reason') reason: string,
     @Req() req: any,
   ) {
-    return this.chaptersService.reportQuizAbandon(moduleId, req.user.id, reason || 'tab_switch');
+    return this.chaptersService.reportQuizAbandon(
+      moduleId,
+      req.user.id,
+      reason || 'tab_switch',
+    );
   }
 
   /** PATCH /api/chapters/modules/:moduleId — admin update module */
@@ -106,7 +124,10 @@ export class ChaptersController {
   @Put('modules/:id/questions')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('admin')
-  replaceModuleQuestions(@Param('id') id: string, @Body() body: { questions: any[] }) {
+  replaceModuleQuestions(
+    @Param('id') id: string,
+    @Body() body: { questions: any[] },
+  ) {
     return this.chaptersService.replaceModuleQuestions(id, body.questions);
   }
 


### PR DESCRIPTION
- Install @nestjs/throttler package
- Global throttling: 60 req/min per IP
- Login endpoint: 5 attempts/15 min per IP
- Quiz submit endpoint: 10 req/min per authenticated user
- Return 429 response with Retry-After header

closes: #30 