### PR TITLE
feat: add dual anti-double-claim validation

### DIFF
--- a/Services-Tonalli/src/chapters/chapters.service.ts
+++ b/Services-Tonalli/src/chapters/chapters.service.ts
@@ -432,6 +432,8 @@ export class ChaptersService {
 
     const isFinalExam = mod.type === 'final_exam';
 
+    const alreadyCompletedWithPassing = progress.completed && progress.score >= mod.passingScore;
+
     if (isFinalExam) {
       progress.attempts += 1;
       progress.score = Math.max(progress.score, score);
@@ -441,6 +443,17 @@ export class ChaptersService {
     }
 
     if (passed) {
+      if (alreadyCompletedWithPassing) {
+        return {
+          score, passed, correctCount: correct, totalQuestions: answers.length, results,
+          xpEarned: 0,
+          livesRemaining: -1,
+          moduleCompleted: true,
+          alreadyCompleted: true,
+          message: 'Este módulo ya fue completado anteriormente.',
+        };
+      }
+
       if (isFinalExam && !progress.completed) {
         progress.completed = true;
         progress.score = Math.max(progress.score, score);
@@ -469,16 +482,19 @@ export class ChaptersService {
           }
 
           // On-chain XLM reward via Learn-to-Earn contract
-          try {
-            const xlmAmount = (mod.xpReward || 50) / 100; // 0.5 XLM per 50 XP
-            await this.sorobanService.rewardUser({
-              userPublicKey: user.stellarPublicKey,
-              lessonId: mod.chapterId,
-              amountXlm: xlmAmount,
-              score,
-            });
-          } catch (e) {
-            console.error('On-chain reward error:', e.message);
+          if (!progress.rewardSent) {
+            try {
+              const xlmAmount = (mod.xpReward || 50) / 100; // 0.5 XLM per 50 XP
+              await this.sorobanService.rewardUser({
+                userPublicKey: user.stellarPublicKey,
+                lessonId: mod.chapterId,
+                amountXlm: xlmAmount,
+                score,
+              });
+              progress.rewardSent = true;
+            } catch (e) {
+              console.error('On-chain reward error:', e.message);
+            }
           }
 
           // Mint TNL tokens
@@ -502,7 +518,7 @@ export class ChaptersService {
           await this.usersRepo.save(user);
 
           // On-chain XLM reward via Learn-to-Earn contract for lesson modules
-          if (user.stellarPublicKey) {
+          if (user.stellarPublicKey && !progress.rewardSent) {
             try {
               const xlmAmount = (mod.xpReward || 30) / 100; // 0.3 XLM per 30 XP
               await this.sorobanService.rewardUser({
@@ -511,6 +527,7 @@ export class ChaptersService {
                 amountXlm: xlmAmount,
                 score,
               });
+              progress.rewardSent = true;
             } catch (e) {
               console.error('On-chain reward error (module):', e.message);
             }
@@ -678,7 +695,7 @@ export class ChaptersService {
         userId, chapterId, moduleId,
         infoCompleted: false, videoCompleted: false, videoProgress: 0,
         quizCompleted: false, quizScore: 0, quizAttempts: 0,
-        completed: false, score: 0, attempts: 0, xpEarned: 0,
+        completed: false, score: 0, attempts: 0, xpEarned: 0, rewardSent: false,
       });
       progress = await this.progressRepo.save(progress);
     }

--- a/Services-Tonalli/src/chapters/entities/chapter-progress.entity.ts
+++ b/Services-Tonalli/src/chapters/entities/chapter-progress.entity.ts
@@ -55,6 +55,9 @@ export class ChapterProgress {
   @Column({ default: false })
   completed: boolean;
 
+  @Column({ default: false })
+  rewardSent: boolean;
+
   @Column({ default: 0 })
   score: number; // best quiz score
 


### PR DESCRIPTION
- Check DB if module already completed before calling Soroban contract
- Add rewardSent boolean field to ChapterProgress entity
- Skip contract calls and return early if module already completed with passing score

closes: #6 