### PR TITLE
feat(security): encrypt stellar secret keys in database [M0-001]

### DIFF
--- a/Services-Tonalli/.env.example
+++ b/Services-Tonalli/.env.example
@@ -1,0 +1,24 @@
+# Database
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+DB_PASS=
+DB_NAME=tonalli
+
+# JWT
+JWT_SECRET=your-jwt-secret-here
+
+# Stellar
+STELLAR_ADMIN_SECRET=
+STELLAR_NETWORK=testnet
+
+# ACTA
+ACTA_API_KEY=
+ACTA_BASE_URL=https://api.acta.build
+
+# Encryption (64 hex chars = 32 bytes)
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ENCRYPTION_MASTER_KEY=
+
+# App
+PORT=3001

--- a/Services-Tonalli/package-lock.json
+++ b/Services-Tonalli/package-lock.json
@@ -50,7 +50,7 @@
         "prettier": "^3.4.2",
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
-        "ts-jest": "^29.2.5",
+        "ts-jest": "^29.4.9",
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
@@ -6790,9 +6790,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11356,19 +11356,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -11385,7 +11385,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {

--- a/Services-Tonalli/package.json
+++ b/Services-Tonalli/package.json
@@ -63,7 +63,7 @@
     "prettier": "^3.4.2",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
-    "ts-jest": "^29.2.5",
+    "ts-jest": "^29.4.9",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",

--- a/Services-Tonalli/src/app.module.ts
+++ b/Services-Tonalli/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -26,6 +26,8 @@ import { Quiz } from './lessons/entities/quiz.entity';
 import { Progress } from './progress/entities/progress.entity';
 import { NFTCertificate } from './progress/entities/nft-certificate.entity';
 import { Streak } from './users/entities/streak.entity';
+import { EncryptionService } from './common/encryption.service';
+import { UserSubscriber } from './users/subscribers/user.subscriber';
 
 @Module({
   imports: [
@@ -35,7 +37,7 @@ import { Streak } from './users/entities/streak.entity';
     }),
     ScheduleModule.forRoot(),
     TypeOrmModule.forRootAsync({
-      useFactory: () => ({
+      useFactory: (encryptionService: EncryptionService): TypeOrmModuleOptions => ({
         type: 'mysql',
         host: process.env.DB_HOST || 'localhost',
         port: parseInt(process.env.DB_PORT || '3306'),
@@ -43,10 +45,13 @@ import { Streak } from './users/entities/streak.entity';
         password: process.env.DB_PASS || '',
         database: process.env.DB_NAME || 'tonalli',
         entities: [User, Lesson, Quiz, Progress, NFTCertificate, Streak, Chapter, ChapterModuleEntity, ChapterProgress, ChapterQuestion, WeeklyScore, PodiumReward, ActaCertificate],
-        synchronize: true,   // crea/actualiza tablas automáticamente
+        synchronize: true,
         logging: false,
         charset: 'utf8mb4',
+        subscribers: [new UserSubscriber(encryptionService)] as any,
       }),
+      imports: [ConfigModule],
+      inject: [EncryptionService],
     }),
     AuthModule,
     UsersModule,
@@ -59,6 +64,9 @@ import { Streak } from './users/entities/streak.entity';
     ActaModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    EncryptionService,
+  ],
 })
 export class AppModule {}

--- a/Services-Tonalli/src/common/encryption.service.spec.ts
+++ b/Services-Tonalli/src/common/encryption.service.spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EncryptionService } from './encryption.service';
+
+describe('EncryptionService', () => {
+  let service: EncryptionService;
+
+  const TEST_MASTER_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+  beforeEach(async () => {
+    process.env.ENCRYPTION_MASTER_KEY = TEST_MASTER_KEY;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EncryptionService],
+    }).compile();
+
+    service = module.get<EncryptionService>(EncryptionService);
+  });
+
+  afterEach(() => {
+    delete process.env.ENCRYPTION_MASTER_KEY;
+  });
+
+  describe('encrypt and decrypt', () => {
+    it('should encrypt and decrypt a secret key correctly', () => {
+      const plaintext = 'SCZOWNMBYJ7GZCYV3DSMXKV3VMT3GZ2XI5B3FPZTE2IUQRR7HYCWX2W';
+      const encrypted = service.encrypt(plaintext);
+      const decrypted = service.decrypt(encrypted);
+
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it('should produce different ciphertext for same plaintext (random IV)', () => {
+      const plaintext = 'SCZOWNMBYJ7GZCYV3DSMXKV3VMT3GZ2XI5B3FPZTE2IUQRR7HYCWX2W';
+      const encrypted1 = service.encrypt(plaintext);
+      const encrypted2 = service.encrypt(plaintext);
+
+      expect(encrypted1).not.toBe(encrypted2);
+    });
+
+    it('should return null as-is without throwing', () => {
+      expect(service.encrypt(null as any)).toBeNull();
+      expect(service.decrypt(null as any)).toBeNull();
+    });
+
+    it('should return undefined as-is without throwing', () => {
+      expect(service.encrypt(undefined as any)).toBeUndefined();
+      expect(service.decrypt(undefined as any)).toBeUndefined();
+    });
+
+    it('should handle special characters', () => {
+      const plaintext = '!@#$%^&*()_+-=[]{}|;:,.<>?';
+      const encrypted = service.encrypt(plaintext);
+      const decrypted = service.decrypt(encrypted);
+
+      expect(decrypted).toBe(plaintext);
+    });
+  });
+
+  describe('isEncrypted', () => {
+    it('should return true for encrypted value', () => {
+      const encrypted = service.encrypt('some-secret');
+      expect(service.isEncrypted(encrypted)).toBe(true);
+    });
+
+    it('should return false for plaintext secret key', () => {
+      const plaintext = 'SCZOWNMBYJ7GZCYV3DSMXKV3VMT3GZ2XI5B3FPZTE2IUQRR7HYCWX2W';
+      expect(service.isEncrypted(plaintext)).toBe(false);
+    });
+
+    it('should return false for null or undefined', () => {
+      expect(service.isEncrypted(null as any)).toBe(false);
+      expect(service.isEncrypted(undefined as any)).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(service.isEncrypted('')).toBe(false);
+    });
+
+    it('should return false for value without proper format', () => {
+      expect(service.isEncrypted('just-a-plain-text')).toBe(false);
+      expect(service.isEncrypted('incomplete:format')).toBe(false);
+    });
+  });
+
+  describe('decrypt with invalid input', () => {
+    it('should throw error for invalid ciphertext format', () => {
+      expect(() => service.decrypt('invalid')).toThrow('Invalid ciphertext format');
+    });
+  });
+});

--- a/Services-Tonalli/src/common/encryption.service.ts
+++ b/Services-Tonalli/src/common/encryption.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+import * as crypto from 'crypto';
+
+@Injectable()
+export class EncryptionService {
+  private readonly algorithm = 'aes-256-gcm';
+  private readonly ivLength = 16;
+  private readonly authTagLength = 16;
+  private readonly key: Buffer;
+
+  constructor() {
+    const masterKey = process.env.ENCRYPTION_MASTER_KEY;
+    if (!masterKey) {
+      throw new Error('ENCRYPTION_MASTER_KEY environment variable is required');
+    }
+    if (masterKey.length !== 64) {
+      throw new Error('ENCRYPTION_MASTER_KEY must be 64 hex characters (32 bytes)');
+    }
+    this.key = Buffer.from(masterKey, 'hex');
+  }
+
+  encrypt(plaintext: string): string {
+    if (!plaintext) return plaintext;
+    const iv = crypto.randomBytes(this.ivLength);
+    const cipher = crypto.createCipheriv(this.algorithm, this.key, iv);
+
+    let encrypted = cipher.update(plaintext, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+
+    const authTag = cipher.getAuthTag();
+
+    return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
+  }
+
+  decrypt(ciphertext: string): string {
+    if (!ciphertext) return ciphertext;
+    const parts = ciphertext.split(':');
+    if (parts.length !== 3) {
+      throw new Error('Invalid ciphertext format');
+    }
+
+    const iv = Buffer.from(parts[0], 'hex');
+    const authTag = Buffer.from(parts[1], 'hex');
+    const encrypted = parts[2];
+
+    const decipher = crypto.createDecipheriv(this.algorithm, this.key, iv);
+    decipher.setAuthTag(authTag);
+
+    let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+
+    return decrypted;
+  }
+
+  isEncrypted(value: string): boolean {
+    if (!value) return false;
+    return value.includes(':') && value.split(':').length === 3;
+  }
+}

--- a/Services-Tonalli/src/common/interceptors/secret-key-sanitizer.interceptor.ts
+++ b/Services-Tonalli/src/common/interceptors/secret-key-sanitizer.interceptor.ts
@@ -1,0 +1,50 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable()
+export class SecretKeySanitizerInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const request = context.switchToHttp().getRequest();
+    const isExportSecret =
+      request.method === 'POST' &&
+      request.url.includes('/users/me/wallet/export-secret');
+
+    return next.handle().pipe(
+      map((data) => {
+        if (isExportSecret) {
+          return data;
+        }
+        return this.sanitize(data);
+      }),
+    );
+  }
+
+  private sanitize(obj: any): any {
+    if (obj === null || obj === undefined) {
+      return obj;
+    }
+
+    if (Array.isArray(obj)) {
+      return obj.map((item) => this.sanitize(item));
+    }
+
+    if (typeof obj === 'object') {
+      const sanitized: any = {};
+      for (const key of Object.keys(obj)) {
+        if (key === 'stellarSecretKey') {
+          continue;
+        }
+        sanitized[key] = this.sanitize(obj[key]);
+      }
+      return sanitized;
+    }
+
+    return obj;
+  }
+}

--- a/Services-Tonalli/src/database/migrations/20260427214552-encrypt-stellar-secret-keys.ts
+++ b/Services-Tonalli/src/database/migrations/20260427214552-encrypt-stellar-secret-keys.ts
@@ -1,0 +1,80 @@
+import { MigrationInterface, QueryRunner, DataSource } from 'typeorm';
+import * as crypto from 'crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+
+function getKey(): Buffer {
+  const masterKey = process.env.ENCRYPTION_MASTER_KEY;
+  if (!masterKey || masterKey.length !== 64) {
+    throw new Error('ENCRYPTION_MASTER_KEY must be 64 hex characters');
+  }
+  return Buffer.from(masterKey, 'hex');
+}
+
+function encrypt(plaintext: string): string {
+  const key = getKey();
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+
+  let encrypted = cipher.update(plaintext, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+  const authTag = cipher.getAuthTag();
+
+  return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted}`;
+}
+
+function isEncrypted(value: string): boolean {
+  if (!value) return false;
+  return value.includes(':') && value.split(':').length === 3;
+}
+
+export class EncryptStellarSecretKeys20260427214552 implements MigrationInterface {
+  name = 'EncryptStellarSecretKeys20260427214552';
+  dataSource: DataSource;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const users = await queryRunner.query('SELECT id, stellarSecretKey FROM users WHERE stellarSecretKey IS NOT NULL');
+
+    for (const user of users) {
+      if (user.stellarSecretKey && !isEncrypted(user.stellarSecretKey)) {
+        const encrypted = encrypt(user.stellarSecretKey);
+        await queryRunner.query(
+          'UPDATE users SET stellarSecretKey = ? WHERE id = ?',
+          [encrypted, user.id],
+        );
+      }
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const masterKey = process.env.ENCRYPTION_MASTER_KEY;
+    if (!masterKey) {
+      throw new Error('ENCRYPTION_MASTER_KEY required for rollback');
+    }
+
+    const key = Buffer.from(masterKey, 'hex');
+    const users = await queryRunner.query('SELECT id, stellarSecretKey FROM users WHERE stellarSecretKey IS NOT NULL');
+
+    for (const user of users) {
+      if (user.stellarSecretKey && isEncrypted(user.stellarSecretKey)) {
+        const parts = user.stellarSecretKey.split(':');
+        const iv = Buffer.from(parts[0], 'hex');
+        const authTag = Buffer.from(parts[1], 'hex');
+        const encrypted = parts[2];
+
+        const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+        decipher.setAuthTag(authTag);
+
+        let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+        decrypted += decipher.final('utf8');
+
+        await queryRunner.query(
+          'UPDATE users SET stellarSecretKey = ? WHERE id = ?',
+          [decrypted, user.id],
+        );
+      }
+    }
+  }
+}

--- a/Services-Tonalli/src/main.ts
+++ b/Services-Tonalli/src/main.ts
@@ -1,9 +1,12 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
+import { SecretKeySanitizerInterceptor } from './common/interceptors/secret-key-sanitizer.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.useGlobalInterceptors(new SecretKeySanitizerInterceptor());
 
   app.enableCors({
     origin: ['http://localhost:3000', 'http://localhost:5173', 'http://localhost:8081'],

--- a/Services-Tonalli/src/users/subscribers/user.subscriber.ts
+++ b/Services-Tonalli/src/users/subscribers/user.subscriber.ts
@@ -1,0 +1,40 @@
+import {
+  EntitySubscriberInterface,
+  EventSubscriber,
+  LoadEvent,
+  InsertEvent,
+  UpdateEvent,
+} from 'typeorm';
+import { User } from '../entities/user.entity';
+import { EncryptionService } from '../../common/encryption.service';
+
+@EventSubscriber()
+export class UserSubscriber implements EntitySubscriberInterface<User> {
+  constructor(
+    private readonly encryptionService: EncryptionService,
+  ) {}
+
+  listenTo() {
+    return User;
+  }
+
+  afterLoad(entity: User): void {
+    if (entity.stellarSecretKey && this.encryptionService.isEncrypted(entity.stellarSecretKey)) {
+      entity.stellarSecretKey = this.encryptionService.decrypt(entity.stellarSecretKey);
+    }
+  }
+
+  beforeInsert(event: InsertEvent<User>): void {
+    const entity = event.entity;
+    if (entity.stellarSecretKey && !this.encryptionService.isEncrypted(entity.stellarSecretKey)) {
+      entity.stellarSecretKey = this.encryptionService.encrypt(entity.stellarSecretKey);
+    }
+  }
+
+  beforeUpdate(event: UpdateEvent<User>): void {
+    const entity = event.entity;
+    if (entity?.stellarSecretKey && !this.encryptionService.isEncrypted(entity.stellarSecretKey)) {
+      entity.stellarSecretKey = this.encryptionService.encrypt(entity.stellarSecretKey);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
The `stellarSecretKey` field was stored in plain text in the database.
Adds AES-256-GCM encryption so that a compromised database
does not expose user wallet keys.

## Changes
- EncryptionService: using Node.js native `crypto` (AES-256-GCM,
  random IV per encryption, format `iv:authTag:ciphertext`)
- UserSubscriber: that encrypts on insert/update and decrypts
  on load transparently
- SecretKeySanitizerInterceptor: registered globally to strip
  `stellarSecretKey` from all API responses
- Added migration to re-encrypt existing plain text records
- Updated app.module.ts to register subscriber via TypeORM
- Updated main.ts to register the interceptor globally
- Added `ENCRYPTION_MASTER_KEY` to `.env.example` with generation instructions

## Testing
- 11 unit tests covering the encrypt/decrypt round-trip, random IV,
  null/undefined handling, and invalid input

<img width="786" height="605" alt="Captura de pantalla 2026-04-28 090829" src="https://github.com/user-attachments/assets/2f56279c-41dd-46ce-b5c3-73d8aafd7b68" />

- npm run build passes with no errors
- Verified that no endpoint exposes stellarSecretKey except
  `POST /api/users/me/wallet/export-secret` (password-protected)

## Notes
- `ENCRYPTION_MASTER_KEY` must be added to `.env` before deploying.
  Generate with:
  `node -e “console.log(require(‘crypto’).randomBytes(32).toString(‘hex’))”`
- Migration runs on next deploy and re-encrypts existing records.
  Rollback available via `down()` method.
- app.controller.spec.ts failure is pre-existing and unrelated to
  this PR.


Closes #1 