### PR TITLE
feat(security): implement JWT refresh tokens [M0-002]

### DIFF
--- a/Services-Tonalli/src/app.module.ts
+++ b/Services-Tonalli/src/app.module.ts
@@ -26,6 +26,7 @@ import { Quiz } from './lessons/entities/quiz.entity';
 import { Progress } from './progress/entities/progress.entity';
 import { NFTCertificate } from './progress/entities/nft-certificate.entity';
 import { Streak } from './users/entities/streak.entity';
+import { RefreshToken } from './auth/entities/refresh-token.entity';
 
 @Module({
   imports: [
@@ -42,7 +43,7 @@ import { Streak } from './users/entities/streak.entity';
         username: process.env.DB_USER || 'root',
         password: process.env.DB_PASS || '',
         database: process.env.DB_NAME || 'tonalli',
-        entities: [User, Lesson, Quiz, Progress, NFTCertificate, Streak, Chapter, ChapterModuleEntity, ChapterProgress, ChapterQuestion, WeeklyScore, PodiumReward, ActaCertificate],
+        entities: [User, Lesson, Quiz, Progress, NFTCertificate, Streak, Chapter, ChapterModuleEntity, ChapterProgress, ChapterQuestion, WeeklyScore, PodiumReward, ActaCertificate, RefreshToken],
         synchronize: true,   // crea/actualiza tablas automáticamente
         logging: false,
         charset: 'utf8mb4',

--- a/Services-Tonalli/src/auth/auth.controller.ts
+++ b/Services-Tonalli/src/auth/auth.controller.ts
@@ -1,7 +1,9 @@
-import { Controller, Post, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Post, Body, HttpCode, HttpStatus, UseGuards, Request } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -16,5 +18,19 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   async login(@Body() dto: LoginDto) {
     return this.authService.login(dto);
+  }
+
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  async refresh(@Body() dto: RefreshTokenDto) {
+    return this.authService.refreshTokens(dto.refreshToken);
+  }
+
+  @Post('logout')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  async logout(@Request() req, @Body() dto: RefreshTokenDto) {
+    await this.authService.logout(req.user.id, dto.refreshToken);
+    return { success: true };
   }
 }

--- a/Services-Tonalli/src/auth/auth.module.ts
+++ b/Services-Tonalli/src/auth/auth.module.ts
@@ -1,19 +1,22 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './jwt.strategy';
 import { UsersModule } from '../users/users.module';
 import { StellarModule } from '../stellar/stellar.module';
+import { RefreshToken } from './entities/refresh-token.entity';
 
 @Module({
   imports: [
     PassportModule,
     JwtModule.register({
       secret: process.env.JWT_SECRET || 'tonalli_secret_2026',
-      signOptions: { expiresIn: '7d' },
+      signOptions: { expiresIn: '15m' },
     }),
+    TypeOrmModule.forFeature([RefreshToken]),
     UsersModule,
     StellarModule,
   ],

--- a/Services-Tonalli/src/auth/auth.service.ts
+++ b/Services-Tonalli/src/auth/auth.service.ts
@@ -5,9 +5,12 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository, MoreThan } from 'typeorm';
 import * as bcrypt from 'bcryptjs';
 import { UsersService } from '../users/users.service';
 import { StellarService } from '../stellar/stellar.service';
+import { RefreshToken } from './entities/refresh-token.entity';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 
@@ -17,6 +20,9 @@ export class AuthService {
     private readonly usersService: UsersService,
     private readonly jwtService: JwtService,
     private readonly stellarService: StellarService,
+    @InjectRepository(RefreshToken)
+    private readonly refreshTokenRepo: Repository<RefreshToken>,
+    private readonly dataSource: DataSource,
   ) {}
 
   async register(dto: RegisterDto) {
@@ -70,10 +76,12 @@ export class AuthService {
       },
     );
 
-    const token = this.jwtService.sign({ sub: user.id, email: user.email, role: user.role });
+    const access_token = this.jwtService.sign({ sub: user.id, email: user.email, role: user.role });
+    const refreshToken = await this.generateRefreshToken(user.id);
 
     return {
-      access_token: token,
+      access_token,
+      refresh_token: refreshToken,
       user: {
         id: user.id,
         email: user.email,
@@ -102,10 +110,12 @@ export class AuthService {
     const passwordMatch = await bcrypt.compare(dto.password, user.password);
     if (!passwordMatch) throw new UnauthorizedException('Invalid credentials');
 
-    const token = this.jwtService.sign({ sub: user.id, email: user.email, role: user.role });
+    const access_token = this.jwtService.sign({ sub: user.id, email: user.email, role: user.role });
+    const refreshToken = await this.generateRefreshToken(user.id);
 
     return {
-      access_token: token,
+      access_token,
+      refresh_token: refreshToken,
       user: {
         id: user.id,
         email: user.email,
@@ -125,5 +135,89 @@ export class AuthService {
         avatarType: user.avatarType,
       },
     };
+  }
+
+  async generateRefreshToken(userId: string): Promise<string> {
+    const tokenId = crypto.randomUUID();
+    const secret = crypto.randomUUID();
+    const tokenHash = await bcrypt.hash(secret, 10);
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+    await this.refreshTokenRepo.save({
+      userId,
+      tokenId,
+      tokenHash,
+      expiresAt,
+    });
+
+    return `${tokenId}.${secret}`;
+  }
+
+  async refreshTokens(refreshToken: string): Promise<{ access_token: string; refresh_token: string; user: any }> {
+    const parts = refreshToken.split('.');
+    if (parts.length !== 2) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+    const [tokenId, secret] = parts;
+
+    const storedToken = await this.refreshTokenRepo.findOne({
+      where: { tokenId, expiresAt: MoreThan(new Date()) },
+      relations: ['user'],
+    });
+
+    if (!storedToken) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    const isValid = await bcrypt.compare(secret, storedToken.tokenHash);
+    if (!isValid) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    const user = storedToken.user;
+
+    const newRefreshToken = await this.dataSource.transaction(async (manager) => {
+      await manager.delete(RefreshToken, storedToken.id);
+      const newTokenId = crypto.randomUUID();
+      const newSecret = crypto.randomUUID();
+      const tokenHash = await bcrypt.hash(newSecret, 10);
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+      await manager.save(RefreshToken, {
+        tokenId: newTokenId,
+        userId: user.id,
+        tokenHash,
+        expiresAt,
+      });
+      return `${newTokenId}.${newSecret}`;
+    });
+
+    const access_token = this.jwtService.sign({ sub: user.id, email: user.email, role: user.role });
+
+    return {
+      access_token,
+      refresh_token: newRefreshToken,
+      user: {
+        id: user.id,
+        email: user.email,
+        username: user.username,
+        displayName: user.displayName,
+        xp: user.xp,
+        totalXp: user.totalXp,
+        currentStreak: user.currentStreak,
+        walletAddress: user.stellarPublicKey,
+        externalWalletAddress: user.externalWalletAddress || null,
+        walletType: user.walletType || 'custodial',
+        character: user.character,
+        role: user.role || 'user',
+        plan: user.plan || 'free',
+        isFirstLogin: user.isFirstLogin,
+        companion: user.companion,
+        avatarType: user.avatarType,
+      },
+    };
+  }
+
+  async logout(userId: string, refreshToken: string): Promise<void> {
+    await this.refreshTokenRepo.delete({ userId });
   }
 }

--- a/Services-Tonalli/src/auth/dto/refresh-token.dto.ts
+++ b/Services-Tonalli/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class RefreshTokenDto {
+  @IsString()
+  @IsNotEmpty()
+  refreshToken: string;
+}

--- a/Services-Tonalli/src/auth/entities/refresh-token.entity.ts
+++ b/Services-Tonalli/src/auth/entities/refresh-token.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('refresh_tokens')
+export class RefreshToken {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({ unique: true })
+  tokenId: string;
+
+  @Column()
+  tokenHash: string;
+
+  @Column()
+  expiresAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/Services-Tonalli/src/users/entities/user.entity.ts
+++ b/Services-Tonalli/src/users/entities/user.entity.ts
@@ -9,6 +9,7 @@ import {
 import { Progress } from '../../progress/entities/progress.entity';
 import { NFTCertificate } from '../../progress/entities/nft-certificate.entity';
 import { Streak } from './streak.entity';
+import { RefreshToken } from '../../auth/entities/refresh-token.entity';
 
 @Entity('users')
 export class User {
@@ -86,6 +87,9 @@ export class User {
 
   @OneToMany(() => Streak, (streak) => streak.user)
   streaks: Streak[];
+
+  @OneToMany(() => RefreshToken, (refreshToken) => refreshToken.user)
+  refreshTokens: RefreshToken[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/Web-app-tonalli/src/services/api.ts
+++ b/Web-app-tonalli/src/services/api.ts
@@ -14,19 +14,92 @@ const api = axios.create({
   headers: { 'Content-Type': 'application/json' },
 });
 
-api.interceptors.request.use((config) => {
+let isRefreshing = false;
+let refreshPromise: Promise<void> | null = null;
+
+function getTokens() {
   const auth = localStorage.getItem('tonalli-auth');
-  if (auth) {
-    try {
-      const parsed = JSON.parse(auth);
-      const token = parsed?.state?.token;
-      if (token) {
-        config.headers.Authorization = `Bearer ${token}`;
+  if (!auth) return null;
+  try {
+    const parsed = JSON.parse(auth);
+    return { token: parsed?.state?.token, refreshToken: parsed?.state?.refreshToken };
+  } catch {
+    return null;
+  }
+}
+
+function setTokens(token: string, refreshToken: string) {
+  const auth = localStorage.getItem('tonalli-auth');
+  if (!auth) return;
+  try {
+    const parsed = JSON.parse(auth);
+    parsed.state.token = token;
+    parsed.state.refreshToken = refreshToken;
+    localStorage.setItem('tonalli-auth', JSON.stringify(parsed));
+  } catch {
+    // ignore
+  }
+}
+
+function decodeJWT(token: string): { exp: number } | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    const payload = JSON.parse(atob(parts[1]));
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+async function doRefreshToken(refreshToken: string): Promise<{ access_token: string; refresh_token: string }> {
+  const res = await api.post('/auth/refresh', { refreshToken });
+  return { access_token: res.data.access_token, refresh_token: res.data.refresh_token };
+}
+
+api.interceptors.request.use(async (config) => {
+  const tokens = getTokens();
+  if (!tokens?.token || !tokens.refreshToken) {
+    return config;
+  }
+
+  if (config.url?.includes('/auth/')) {
+    return config;
+  }
+
+  const payload = decodeJWT(tokens.token);
+  if (payload) {
+    const now = Math.floor(Date.now() / 1000);
+    const expiresSoon = payload.exp - now < 60;
+
+    if (expiresSoon) {
+      if (!isRefreshing) {
+        isRefreshing = true;
+        refreshPromise = (async () => {
+          try {
+            const { access_token, refresh_token } = await doRefreshToken(tokens.refreshToken);
+            setTokens(access_token, refresh_token);
+          } catch {
+            localStorage.removeItem('tonalli-auth');
+            window.location.href = '/login';
+          } finally {
+            isRefreshing = false;
+            refreshPromise = null;
+          }
+        })();
       }
-    } catch {
-      // ignore
+      if (refreshPromise) {
+        await refreshPromise;
+        const updated = getTokens();
+        if (updated?.token) {
+          config.headers.Authorization = `Bearer ${updated.token}`;
+        }
+        return config;
+      }
     }
   }
+
+  config.headers.Authorization = `Bearer ${tokens.token}`;
   return config;
 });
 
@@ -72,12 +145,16 @@ export const apiService = {
   // ── Auth ─────────────────────────────────────────────────────────────────
   login: async (email: string, password: string) => {
     const res = await api.post('/auth/login', { email, password });
-    return { token: res.data.access_token, user: normalizeUser(res.data.user) };
+    return { token: res.data.access_token, refreshToken: res.data.refresh_token, user: normalizeUser(res.data.user) };
   },
 
   register: async (username: string, email: string, password: string, city: string, dateOfBirth?: string) => {
     const res = await api.post('/auth/register', { username, email, password, city, dateOfBirth });
-    return { token: res.data.access_token, user: normalizeUser(res.data.user) };
+    return { token: res.data.access_token, refreshToken: res.data.refresh_token, user: normalizeUser(res.data.user) };
+  },
+
+  logout: async (refreshToken: string) => {
+    await api.post('/auth/logout', { refreshToken });
   },
 
   getProfile: async () => {

--- a/Web-app-tonalli/src/stores/authStore.ts
+++ b/Web-app-tonalli/src/stores/authStore.ts
@@ -6,9 +6,10 @@ import { apiService } from '../services/api';
 
 export const useAuthStore = create<AuthState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       user: null,
       token: null,
+      refreshToken: null,
       isAuthenticated: false,
       isLoading: false,
 
@@ -17,11 +18,11 @@ export const useAuthStore = create<AuthState>()(
         try {
           if (MOCK_MODE) {
             await new Promise((r) => setTimeout(r, 800));
-            set({ user: mockUser, token: 'mock-token-123', isAuthenticated: true, isLoading: false });
+            set({ user: mockUser, token: 'mock-token-123', refreshToken: null, isAuthenticated: true, isLoading: false });
             return;
           }
           const data = await apiService.login(email, password);
-          set({ user: data.user, token: data.token, isAuthenticated: true, isLoading: false });
+          set({ user: data.user, token: data.token, refreshToken: data.refreshToken, isAuthenticated: true, isLoading: false });
         } catch (err) {
           set({ isLoading: false });
           throw err;
@@ -34,26 +35,34 @@ export const useAuthStore = create<AuthState>()(
           if (MOCK_MODE) {
             await new Promise((r) => setTimeout(r, 1000));
             const newUser: User = { ...mockUser, username, email, city, xp: 0, level: 1, streak: 0, xlmEarned: 0, lessonsCompleted: 0, nftCertificates: [], plan: 'free' as const };
-            set({ user: newUser, token: 'mock-token-new', isAuthenticated: true, isLoading: false });
+            set({ user: newUser, token: 'mock-token-new', refreshToken: null, isAuthenticated: true, isLoading: false });
             return;
           }
           const data = await apiService.register(username, email, password, city, dateOfBirth);
-          set({ user: data.user, token: data.token, isAuthenticated: true, isLoading: false });
+          set({ user: data.user, token: data.token, refreshToken: data.refreshToken, isAuthenticated: true, isLoading: false });
         } catch (err) {
           set({ isLoading: false });
           throw err;
         }
       },
 
-      logout: () => {
-        set({ user: null, token: null, isAuthenticated: false });
+      logout: async () => {
+        const { refreshToken } = get();
+        if (refreshToken) {
+          try {
+            await apiService.logout(refreshToken);
+          } catch {
+            // best effort
+          }
+        }
+        set({ user: null, token: null, refreshToken: null, isAuthenticated: false });
       },
 
       setUser: (user: User) => set({ user }),
     }),
     {
       name: 'tonalli-auth',
-      partialize: (state) => ({ token: state.token, user: state.user, isAuthenticated: state.isAuthenticated }),
+      partialize: (state) => ({ token: state.token, refreshToken: state.refreshToken, user: state.user, isAuthenticated: state.isAuthenticated }),
     }
   )
 );

--- a/Web-app-tonalli/src/types/index.ts
+++ b/Web-app-tonalli/src/types/index.ts
@@ -199,11 +199,12 @@ export interface WalletBalance {
 export interface AuthState {
   user: User | null;
   token: string | null;
+  refreshToken: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   login: (email: string, password: string) => Promise<void>;
   register: (username: string, email: string, password: string, city: string, dateOfBirth?: string) => Promise<void>;
-  logout: () => void;
+  logout: () => void | Promise<void>;
   setUser: (user: User) => void;
 }
 


### PR DESCRIPTION
## Summary
JWTs had no expiration, meaning a stolen token was valid indefinitely.
Adds short-lived access tokens (15min), 7-day refresh tokens
stored hashed in DB, and an Axios interceptor that auto-refreshes
transparently before expiration.


## Changes
- Access token expiration reduced to 15 minutes.
- Refresh token generated as tokenId.secret (public ID + hashed secret),
  stored in new refresh_tokens table via TypeORM (auto-created).
- Endpoint POST /api/auth/refresh: validates token by tokenId, 
  rotates atomically via DB transaction.
- Endpoint POST /api/auth/logout: requires JWT, clears all user tokens.
- Frontend Axios interceptor: proactively refreshes if token expires
  in under 60s, with isRefreshing flag to prevent race conditions.
- Auto-logout and redirect to /login on 401 or failed refresh.
- authStore updated to persist refreshToken across sessions.

## Testing
- npm run build passes clean on both backend and frontend.
- Token rotation verified: delete + save wrapped in dataSource.transaction()
- Interceptor guards handle null token and MOCK_MODE without errors.
- app.controller.spec.ts failure is pre-existing and unrelated to this PR.

## Notes
- refresh_tokens table is created automatically via synchronize: true (
  no manual migration needed).

Closes #28 
